### PR TITLE
Nginx: 1.15.9

### DIFF
--- a/conf
+++ b/conf
@@ -1,4 +1,11 @@
-ssl_protocols               TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+ssl_protocols               TLSv1.2 TLSv1.3;
 ssl_ecdh_curve              X25519:P-256:P-384:P-224:P-521;
-ssl_ciphers                 '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305|ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]:ECDHE+AES128:RSA+AES128:ECDHE+AES256:RSA+AES256:ECDHE+3DES:RSA+3DES';
+ssl_ciphers                 '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305|ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]:ECDHE+AES128:RSA+AES128:ECDHE+AES256:RSA+AES256';
 ssl_prefer_server_ciphers   on;
+
+ssl_ct on;
+ssl_stapling on;
+ssl_stapling_verify on;
+
+ssl_dyn_rec_enable on;
+ssl_dyn_rec_timeout 1000;

--- a/patches/nginx__1.15.9_dynamic_tls.patch
+++ b/patches/nginx__1.15.9_dynamic_tls.patch
@@ -1,0 +1,248 @@
+diff --git a/src/core/nginx.h b/src/core/nginx.h
+index 25f3e7d..febfb3d 100644
+--- a/src/core/nginx.h
++++ b/src/core/nginx.h
+@@ -10,8 +10,8 @@
+ 
+ 
+ #define nginx_version      1015009
+-#define NGINX_VERSION      "1.15.9"
+-#define NGINX_VER          "nginx/" NGINX_VERSION
++#define NGINX_VERSION      "v3.15b9"
++#define NGINX_VER          "K9/" NGINX_VERSION
+ 
+ #ifdef NGX_BUILD
+ #define NGINX_VER_BUILD    NGINX_VER " (" NGX_BUILD ")"
+diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+index e18778e..7b2fd54 100644
+--- a/src/event/ngx_event_openssl.c
++++ b/src/event/ngx_event_openssl.c
+@@ -1497,6 +1497,7 @@ ngx_ssl_create_connection(ngx_ssl_t *ssl, ngx_connection_t *c, ngx_uint_t flags)
+ 
+     sc->buffer = ((flags & NGX_SSL_BUFFER) != 0);
+     sc->buffer_size = ssl->buffer_size;
++    sc->dyn_rec = ssl->dyn_rec;
+ 
+     sc->session_ctx = ssl->ctx;
+ 
+@@ -2349,6 +2350,31 @@ ngx_ssl_send_chain(ngx_connection_t *c, ngx_chain_t *in, off_t limit)
+ 
+     for ( ;; ) {
+ 
++        /* Dynamic record sizing:
++         * We want the initial records to fit into one TCP segment so we don't get
++         * TCP HoL blocking due to TCP Slow Start. A connection always starts with
++         * small records, but after a given amount of records sent, we make the
++         * records larger to reduce header overhead.
++         *
++         * After a connection has idled for a given timeout, begin the process from
++         * the start. The actual parameters are configurable. If dyn_rec_timeout
++         * is 0, we assume dyn_rec is off. */
++         if (c->ssl->dyn_rec.timeout > 0) {
++		if (ngx_current_msec - c->ssl->dyn_rec_last_write > c->ssl->dyn_rec.timeout) {
++			buf->end = buf->start + c->ssl->dyn_rec.size_lo;
++			c->ssl->dyn_rec_records_sent = 0;
++		} else {
++			if (c->ssl->dyn_rec_records_sent >
++			    c->ssl->dyn_rec.threshold * 2) {
++				buf->end = buf->start + c->ssl->buffer_size;
++			} else if (c->ssl->dyn_rec_records_sent > c->ssl->dyn_rec.threshold) {
++				buf->end = buf->start + c->ssl->dyn_rec.size_hi;
++			} else {
++				buf->end = buf->start + c->ssl->dyn_rec.size_lo;
++			}
++		}
++        }
++
+         while (in && buf->last < buf->end && send < limit) {
+             if (in->buf->last_buf || in->buf->flush) {
+                 flush = 1;
+@@ -2456,6 +2482,9 @@ ngx_ssl_write(ngx_connection_t *c, u_char *data, size_t size)
+ 
+     if (n > 0) {
+ 
++	c->ssl->dyn_rec_records_sent++;
++	c->ssl->dyn_rec_last_write = ngx_current_msec;
++
+         if (c->ssl->saved_read_handler) {
+ 
+             c->read->handler = c->ssl->saved_read_handler;
+diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
+index 61da0c5..4a95502 100644
+--- a/src/event/ngx_event_openssl.h
++++ b/src/event/ngx_event_openssl.h
+@@ -68,6 +68,7 @@ struct ngx_ssl_s {
+     SSL_CTX                    *ctx;
+     ngx_log_t                  *log;
+     size_t                      buffer_size;
++    ngx_ssl_dyn_rec_t		dyn_rec;
+ };
+ 
+ 
+@@ -99,6 +100,9 @@ struct ngx_ssl_connection_s {
+     unsigned                    in_early:1;
+     unsigned                    early_preread:1;
+     unsigned                    write_blocked:1;
++    ngx_ssl_dyn_rec_t		dyn_rec;
++    ngx_msec_t			dyn_rec_last_write;
++    ngx_uint_t			dyn_rec_records_sent;
+ };
+ 
+ 
+@@ -108,7 +112,7 @@ struct ngx_ssl_connection_s {
+ #define NGX_SSL_DFLT_BUILTIN_SCACHE  -5
+ 
+ 
+-#define NGX_SSL_MAX_SESSION_SIZE  4096
++#define NGX_SSL_MAX_SESSION_SIZE  16384
+ 
+ typedef struct ngx_ssl_sess_id_s  ngx_ssl_sess_id_t;
+ 
+@@ -126,6 +130,13 @@ struct ngx_ssl_sess_id_s {
+ };
+ 
+ 
++typedef struct {
++    ngx_msec_t			timeout;
++    ngx_uint_t			threshold;
++    size_t			size_lo;
++    size_t			size_hi;
++} ngx_ssl_dyn_rec_t;
++
+ typedef struct {
+     ngx_rbtree_t                session_rbtree;
+     ngx_rbtree_node_t           sentinel;
+diff --git a/src/http/modules/ngx_http_ssl_module.c b/src/http/modules/ngx_http_ssl_module.c
+index 1b2830d..b802506 100644
+--- a/src/http/modules/ngx_http_ssl_module.c
++++ b/src/http/modules/ngx_http_ssl_module.c
+@@ -249,6 +249,41 @@ static ngx_command_t  ngx_http_ssl_commands[] = {
+       offsetof(ngx_http_ssl_srv_conf_t, early_data),
+       NULL },
+ 
++    { ngx_string("ssl_dyn_rec_enable"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_flag_slot,
++      NGX_HTTP_SRV_CONF_OFFSET,
++      offsetof(ngx_http_ssl_srv_conf_t, dyn_rec_enable),
++      NULL },
++
++    { ngx_string("ssl_dyn_rec_timeout"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_msec_slot,
++      NGX_HTTP_SRV_CONF_OFFSET,
++      offsetof(ngx_http_ssl_srv_conf_t, dyn_rec_timeout),
++      NULL },
++
++    { ngx_string("ssl_dyn_rec_size_lo"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_size_slot,
++      NGX_HTTP_SRV_CONF_OFFSET,
++      offsetof(ngx_http_ssl_srv_conf_t, dyn_rec_size_lo),
++      NULL },
++
++    { ngx_string("ssl_dyn_rec_size_hi"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_size_slot,
++      NGX_HTTP_SRV_CONF_OFFSET,
++      offsetof(ngx_http_ssl_srv_conf_t, dyn_rec_size_hi),
++      NULL },
++
++    { ngx_string("ssl_dyn_rec_threshold"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_num_slot,
++      NGX_HTTP_SRV_CONF_OFFSET,
++      offsetof(ngx_http_ssl_srv_conf_t, dyn_rec_threshold),
++      NULL },
++
+       ngx_null_command
+ };
+ 
+@@ -580,6 +615,11 @@ ngx_http_ssl_create_srv_conf(ngx_conf_t *cf)
+     sscf->session_ticket_keys = NGX_CONF_UNSET_PTR;
+     sscf->stapling = NGX_CONF_UNSET;
+     sscf->stapling_verify = NGX_CONF_UNSET;
++    sscf->dyn_rec_enable = NGX_CONF_UNSET;
++    sscf->dyn_rec_timeout = NGX_CONF_UNSET_MSEC;
++    sscf->dyn_rec_size_lo = NGX_CONF_UNSET_SIZE;
++    sscf->dyn_rec_size_hi = NGX_CONF_UNSET_SIZE;
++    sscf->dyn_rec_threshold = NGX_CONF_UNSET_UINT;
+ 
+     return sscf;
+ }
+@@ -647,6 +687,21 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+     ngx_conf_merge_str_value(conf->stapling_responder,
+                          prev->stapling_responder, "");
+ 
++    ngx_conf_merge_value(conf->dyn_rec_enable, prev->dyn_rec_enable, 0);
++    ngx_conf_merge_msec_value(conf->dyn_rec_timeout, prev->dyn_rec_timeout, 1000);
++
++    /* Default sizes for the dynamic record sizes are defined to fit maximal
++     * TLS + IPv6 overhead in a single TCP segment for lo and 3 segments for hi:
++     * 1369 = 1500 - 40 (IP) - 20 (TCP) - 10 (Time) - 61 (Max TLS overhead) */
++    ngx_conf_merge_size_value(conf->dyn_rec_size_lo, prev->dyn_rec_size_lo,
++		    1369);
++
++    /* 4229 = (1500 - 40 - 20 - 10) * 3  - 61 */
++    ngx_conf_merge_size_value(conf->dyn_rec_size_hi, prev->dyn_rec_size_hi,
++		    4229);
++    ngx_conf_merge_uint_value(conf->dyn_rec_threshold, prev->dyn_rec_threshold,
++		    40);
++
+     conf->ssl.log = cf->log;
+ 
+     if (conf->enable) {
+@@ -856,6 +911,24 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+         return NGX_CONF_ERROR;
+     }
+ 
++    if (conf->dyn_rec_enable) {
++	conf->ssl.dyn_rec.timeout = conf->dyn_rec_timeout;
++	conf->ssl.dyn_rec.threshold = conf->dyn_rec_threshold;
++	if (conf->buffer_size > conf->dyn_rec_size_lo) {
++		conf->ssl.dyn_rec.size_lo = conf->dyn_rec_size_lo;
++	} else {
++		conf->ssl.dyn_rec.size_lo = conf->buffer_size;
++	}
++
++	if (conf->buffer_size > conf->dyn_rec_size_hi) {
++		conf->ssl.dyn_rec.size_hi = conf->dyn_rec_size_hi;
++	} else {
++		conf->ssl.-dyn_rec.size_hi = conf->buffer_size;
++	}
++    } else {
++	    conf->ssl.dyn_rec.timeout = 0;
++    }
++
+     return NGX_CONF_OK;
+ }
+ 
+diff --git a/src/http/modules/ngx_http_ssl_module.h b/src/http/modules/ngx_http_ssl_module.h
+index 26fdccf..25d6762 100644
+--- a/src/http/modules/ngx_http_ssl_module.h
++++ b/src/http/modules/ngx_http_ssl_module.h
+@@ -61,6 +61,11 @@ typedef struct {
+ 
+     u_char                         *file;
+     ngx_uint_t                      line;
++    ngx_flag_t			    dyn_rec_enable;
++    ngx_msec_t			    dyn_rec_timeout;
++    size_t			    dyn_rec_size_lo;
++    size_t			    dyn_rec_size_hi;
++    ngx_uint_t			    dyn_rec_threshold;
+ } ngx_http_ssl_srv_conf_t;
+ 
+ 
+diff --git a/src/http/ngx_http_header_filter_module.c b/src/http/ngx_http_header_filter_module.c
+index 9b89405..6b8f3d4 100644
+--- a/src/http/ngx_http_header_filter_module.c
++++ b/src/http/ngx_http_header_filter_module.c
+@@ -46,7 +46,7 @@ ngx_module_t  ngx_http_header_filter_module = {
+ };
+ 
+ 
+-static u_char ngx_http_server_string[] = "Server: nginx" CRLF;
++static u_char ngx_http_server_string[] = "Server: K9" CRLF;
+ static u_char ngx_http_server_full_string[] = "Server: " NGINX_VER CRLF;
+ static u_char ngx_http_server_build_string[] = "Server: " NGINX_VER_BUILD CRLF;
+ 

--- a/proxy
+++ b/proxy
@@ -1,0 +1,3 @@
+proxy_ssl_protocols TLSv1.2;
+proxy_ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE+AES128:ECDHE+AES256';
+proxy_ssl_verify on;


### PR DESCRIPTION
Amends and updates relevant patches for Nginx 1.15.9.

Work so far:
- [x] Dynamic TLS record sizing

Work upstream:
- [x] K9 Nginx `1.15.9` (Bloombox/nginx#1)
- [x] `GOALPOST` (Bloombox/GOALPOST#62)